### PR TITLE
Adding Analog Clock Widget

### DIFF
--- a/blimp-live-widgets/example/src/App.js
+++ b/blimp-live-widgets/example/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import {ExampleComponent, HelloWorld, IFrameComponent} from 'blimp-live-widgets'
+import {ExampleComponent, HelloWorld, IFrameComponent, Clock, ClockThemes} from 'blimp-live-widgets'
 
 export default class App extends Component {
   render () {
@@ -9,6 +9,7 @@ export default class App extends Component {
         <ExampleComponent text='Modern React component module' />
         <HelloWorld />
         <IFrameComponent url="https://www.youtube.com/embed/h_m-BjrxmgI" />
+        <Clock width={300} theme={ClockThemes.navy} />
       </div>
     )
   }

--- a/blimp-live-widgets/example/src/App.js
+++ b/blimp-live-widgets/example/src/App.js
@@ -9,7 +9,7 @@ export default class App extends Component {
         <ExampleComponent text='Modern React component module' />
         <HelloWorld />
         <IFrameComponent url="https://www.youtube.com/embed/h_m-BjrxmgI" />
-        <Clock width={300} theme={ClockThemes.navy} />
+        <Clock width={300} theme={ClockThemes.navy} showSmallTicks={false}/>
       </div>
     )
   }

--- a/blimp-live-widgets/src/components/Clock/ClockLayout.js
+++ b/blimp-live-widgets/src/components/Clock/ClockLayout.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function renderNotches({ smallTick, largeTick }, showSmallTicks) {
+    const notches = [];
+    for (let i = 0; i < 60; i++) {
+        let style = Object.assign({}, i % 5 === 0 ? largeTick : smallTick, {
+            transform: `translateX(-50%) translateY(-100%) rotate(${i * 6}deg)`,
+        });
+        if (i % 5 !== 0 && !showSmallTicks) continue;
+        notches.push(<span key={i} style={style} />);
+    }
+    return notches;
+}
+
+export default function ClockLayout({ hour, minutes, seconds, styles, showSmallTicks }) {
+    // +1 to center align
+    const secondStyle = Object.assign({}, styles.second, {
+        transform: `translateX(-50%) translateY(-100%) rotate(${seconds * 6 + 1}deg)`,
+    });
+    // +1 to center align
+    const minuteStyle = Object.assign({}, styles.minute, {
+        transform: `translateX(-50%) translateY(-100%) rotate(${minutes * 6 + 1}deg)`,
+    });
+    // +1.5 to center align
+    const hourStyle = Object.assign({}, styles.hour, {
+        transform: `translateX(-50%) translateY(-100%) rotate(${hour * 30 + 1.5}deg)`,
+    });
+    return (
+        <div style={styles.base}>
+            <div data-testid="seconds" style={secondStyle}></div>
+            <div data-testid="minutes" style={minuteStyle}></div>
+            <div data-testid="hour" style={hourStyle}></div>
+            <div style={styles.center}></div>
+            {renderNotches(styles, showSmallTicks)}
+        </div>
+    );
+}
+
+ClockLayout.propTypes = {
+    hour: PropTypes.number.isRequired,
+    minutes: PropTypes.number.isRequired,
+    seconds: PropTypes.number.isRequired,
+    styles: PropTypes.shape({
+        second: PropTypes.object.isRequired,
+        minute: PropTypes.object.isRequired,
+        hour: PropTypes.object.isRequired,
+    }).isRequired,
+    showSmallTicks: PropTypes.bool.isRequired,
+};

--- a/blimp-live-widgets/src/components/Clock/index.js
+++ b/blimp-live-widgets/src/components/Clock/index.js
@@ -69,7 +69,7 @@ Clock.propTypes = {
 };
 
 Clock.defaultProps = {
-  theme: Themes.light,
+  theme: Themes.dark,
   width: 400,
   showSmallTicks: true,
 };

--- a/blimp-live-widgets/src/components/Clock/index.js
+++ b/blimp-live-widgets/src/components/Clock/index.js
@@ -1,13 +1,75 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import Styles from './styles'
+import ClockLayout from './ClockLayout';
+import { cssTransform, updateTime } from './utils';
+import * as Themes from './themes';
 
+export const ClockThemes = Themes;
 export default class Clock extends Component {
+
+  constructor(props) {
+    super();
+    const date = this.initializeTime(props.gmtOffset);
+    this.state = {
+      seconds: date[2],
+      minutes: date[1],
+      hour: date[0],
+    };
+    this.styles = cssTransform(Styles, props);
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(() => {
+      this.setState(updateTime(this.state));
+    }, 1000);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.styles = cssTransform(Styles, nextProps);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
+
+  initializeTime(gmtOffset) {
+    const now = new Date();
+    if (gmtOffset && gmtOffset !== 'undefined') {
+      const offsetNow = new Date(now.valueOf() + (parseFloat(gmtOffset) * 1000 * 60 * 60));
+      return [offsetNow.getUTCHours(), offsetNow.getUTCMinutes(), offsetNow.getUTCSeconds()];
+    } else {
+      return [now.getHours(), now.getMinutes(), now.getSeconds()]
+    }
+  }
+
   render() {
 
     return (
       <div>
-        Future Clock
+        <ClockLayout {...this.state} styles={this.styles} showSmallTicks={this.props.showSmallTicks} />
       </div>
     )
   }
 }
+
+Clock.propTypes = {
+  theme: PropTypes.shape({
+          background: PropTypes.string.isRequired,
+          border: PropTypes.string.isRequired,
+          center: PropTypes.string.isRequired,
+          seconds: PropTypes.string.isRequired,
+          minutes: PropTypes.string.isRequired,
+          hour: PropTypes.string.isRequired,
+          tick: PropTypes.string.isRequired,
+  }),
+  width: PropTypes.number,
+  gmtOffset: PropTypes.string,
+  showSmallTicks: PropTypes.bool,
+};
+
+Clock.defaultProps = {
+  theme: Themes.light,
+  width: 400,
+  showSmallTicks: true,
+};

--- a/blimp-live-widgets/src/components/Clock/styles.js
+++ b/blimp-live-widgets/src/components/Clock/styles.js
@@ -1,0 +1,81 @@
+const withDefault = (value, defaultValue) => {
+    if (value === null || value === undefined) return defaultValue;
+    return value;
+};
+
+const AnalogBase = {
+    background: s => s.theme.background,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    borderRadius: '100%',
+    border: s => `${s.width / 20}px solid ${s.theme.border}`,
+    height: s => s.width,
+    position: 'relative',
+    width: s => s.width,
+};
+
+const AnalogCenter = {
+    background: s => s.theme.center,
+    borderRadius: '100%',
+    height: '12px',
+    left: '50%',
+    position: 'absolute',
+    top: '50%',
+    transform: 'translateX(-50%) translateY(-50%)',
+    width: '12px',
+};
+
+const AnalogHand = {
+    left: '50%',
+    position: 'absolute',
+    top: '50%',
+    transformOrigin: '50% 100%',
+};
+
+const AnalogSecondHand = Object.assign({}, AnalogHand, {
+    background: s => s.theme.seconds,
+    height: s => Math.floor(s.width * 0.425),
+    width: s => withDefault(s.theme.secondHandWidth, 3),
+});
+
+const AnalogMinuteHand = Object.assign({}, AnalogHand, {
+    background: s => s.theme.minutes,
+    height: s => Math.floor(s.width * 0.35),
+    width: s => withDefault(s.theme.minuteHandWidth, 6),
+});
+
+const AnalogHourHand = Object.assign({}, AnalogHand, {
+    background: s => s.theme.hour,
+    height: s => Math.floor(s.width * 0.2),
+    width: s => withDefault(s.theme.hourHandWidth, 8),
+});
+
+const AnalogSmallTick = {
+    background: s => s.theme.tick,
+    height: 6,
+    left: '50%',
+    position: 'absolute',
+    top: 6,
+    transformOrigin: s => `0 ${Math.ceil(s.width / 2)}px`,
+    width: s => withDefault(s.theme.smallTickWidth, 2),
+};
+
+const AnalogLargeTick = {
+    background: s => s.theme.tick,
+    height: 10,
+    left: s => Math.ceil(s.width / 2) + 2,
+    position: 'absolute',
+    top: 10,
+    transformOrigin: s => `0 ${Math.ceil(s.width / 2)}px`,
+    width: s => withDefault(s.theme.largeTickWidth, 4),
+};
+
+export default {
+    base: AnalogBase,
+    center: AnalogCenter,
+    second: AnalogSecondHand,
+    minute: AnalogMinuteHand,
+    hour: AnalogHourHand,
+    smallTick: AnalogSmallTick,
+    largeTick: AnalogLargeTick,
+};

--- a/blimp-live-widgets/src/components/Clock/themes.js
+++ b/blimp-live-widgets/src/components/Clock/themes.js
@@ -1,0 +1,89 @@
+export const light = {
+    background: '#fff',
+    border: '#ececec',
+    center: '#000',
+    seconds: '#f56c6c',
+    minutes: '#ccc',
+    hour: '#000',
+    tick: '#000',
+    smallTickWidth: 2,
+    largeTickWidth: 4,
+    secondHandWidth: 3,
+    minuteHandWidth: 6,
+    hourHandWidth: 8,
+};
+
+export const dark = {
+    background: '#000',
+    border: '#000',
+    center: '#fff',
+    seconds: '#fff',
+    minutes: '#ccc',
+    hour: '#fff',
+    tick: '#fff',
+    smallTickWidth: 2,
+    largeTickWidth: 4,
+    secondHandWidth: 3,
+    minuteHandWidth: 6,
+    hourHandWidth: 8,
+};
+
+export const aqua = {
+    background: '#eaeaea',
+    border: '#3dd4c1',
+    center: '#000',
+    seconds: '#f56c6c',
+    minutes: '#9c9c9c',
+    hour: '#000',
+    tick: '#000',
+    smallTickWidth: 2,
+    largeTickWidth: 4,
+    secondHandWidth: 3,
+    minuteHandWidth: 6,
+    hourHandWidth: 8,
+};
+
+export const lime = {
+    background: '#a4f181',
+    border: '#fff',
+    center: '#ccc',
+    seconds: '#fff',
+    minutes: '#ccc',
+    hour: '#fff',
+    tick: '#fff',
+    smallTickWidth: 2,
+    largeTickWidth: 4,
+    secondHandWidth: 3,
+    minuteHandWidth: 6,
+    hourHandWidth: 8,
+};
+
+export const sherbert = {
+    background: 'linear-gradient(to left, #fee , #ddefbb)',
+    border: '#fff',
+    center: '#fff',
+    seconds: '#fff',
+    minutes: '#ccc',
+    hour: '#fff',
+    tick: '#fff',
+    smallTickWidth: 2,
+    largeTickWidth: 4,
+    secondHandWidth: 3,
+    minuteHandWidth: 6,
+    hourHandWidth: 8,
+};
+
+export const navy = {
+    background: 'linear-gradient(#2a70a0,#102d42)',
+    border: '#fff',
+    center: '#fff',
+    seconds: '#fff',
+    minutes: '#ccc',
+    hour: '#fff',
+    tick: '#fff',
+    smallTickWidth: 2,
+    largeTickWidth: 4,
+    secondHandWidth: 3,
+    minuteHandWidth: 6,
+    hourHandWidth: 8,
+};

--- a/blimp-live-widgets/src/components/Clock/utils.js
+++ b/blimp-live-widgets/src/components/Clock/utils.js
@@ -1,0 +1,30 @@
+export function cssTransform(styles, props) {
+    return Object.keys(styles).reduce((newStyles, rootKey) => {
+        const style = styles[rootKey];
+        newStyles[rootKey] = Object.keys(style).reduce((newStyle, key) => {
+            if (typeof style[key] === 'function') {
+                newStyle[key] = style[key](props);
+            } else {
+                newStyle[key] = style[key];
+            }
+            return newStyle;
+        }, {});
+        return newStyles;
+    }, {});
+}
+
+export function updateTime({ seconds, minutes, hour }) {
+    seconds += 1;
+    if (seconds === 60) {
+        seconds = 0;
+        minutes += 1;
+    }
+    if (minutes === 60) {
+        minutes = 0;
+        hour += 1;
+    }
+    if (hour === 12) {
+        hour = 0;
+    }
+    return { seconds, minutes, hour };
+}

--- a/blimp-live-widgets/src/index.js
+++ b/blimp-live-widgets/src/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 // Import your widget here
 import HelloWorld from './components/HelloWorld';
 import ExampleComponent from './components/ExampleComponent';
-import Clock from './components/Clock';
+import Clock, { ClockThemes } from './components/Clock';
 import IFrameComponent from './components/iFrame';
 
 // Export it here
@@ -12,5 +12,6 @@ export {
   HelloWorld,
   ExampleComponent,
   Clock,
+  ClockThemes,
   IFrameComponent,
 }


### PR DESCRIPTION
Adding analog clock widget. 

1. To Render: 

`import {Clock, ClockThemes} from 'blimp-live-widgets';`
`<Clock width={300} theme={ClockThemes.navy} />` 

**PROPS**
showSmallTicks: shows the small 'ticks' on the clock (minute ticks, see screenshots for examples)
width: width of the clock 
theme: set an optional theme for the clock (default dark)


Available Themes: 

- navy 
- lime
- sherbert
- dark
- light
- aqua 

Can also create custom themes by doing: 
```
const customTheme = {
    background: 'transparent',
    border: 'transparent',
    center: 'transparent',
    seconds: '#000',
    minutes: '#000',
    hour: '#000',
    tick: '#000',
    smallTickWidth: 1,
    largeTickWidth: 1,
    secondHandWidth: 1,
    minuteHandWidth: 1,
    hourHandWidth: 1,
};
```

Screenshots: 
```
 <Clock width={300} theme={ClockThemes.navy} showSmallTicks={false}/>
 <Clock width={300} theme={ClockThemes.lime} showSmallTicks={true}/>
```
![Screen Shot 2019-05-21 at 3 11 05 PM](https://user-images.githubusercontent.com/13502814/58123849-cc2b7d80-7bda-11e9-836f-f713e1c92945.png)

```
<Clock width={300} theme={customClockTheme} showSmallTicks={true}/>
```
![Screen Shot 2019-05-21 at 3 11 14 PM](https://user-images.githubusercontent.com/13502814/58123840-c33aac00-7bda-11e9-8326-bfa3a97b9f6d.png)








